### PR TITLE
Fix test profile

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -16,14 +16,6 @@ params {
   max_time = 48.h
   
   // Input data
-  // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
-  // TODO nf-core: Give any required params for the test so that command line flags are not needed
-  input = [ //'/Users/monarchy/Downloads/First_SmallTest_Paired.bam', 
-          //'/Users/monarchy/Downloads/Second_SmallTest_Paired.bam', 
-          //'/Users/monarchy/Downloads//hcc_R1.mLb.clN.sorted.bam', 
-          'https://github.com/nf-core/test-datasets/raw/eager/testdata/Mammoth/bam/JK2782_TGGCCGATCAACGA_L008_R1_001.fastq.gz.tengrand.fq.combined.fq.mapped.bam'
-          //'/Users/monarchy/Downloads/nonsense.bam'
-        ] 
-  outdir = "/Users/monarchy/Downloads/singleEndwithQC"
+  input = 'https://github.com/nf-core/test-datasets/raw/eager/testdata/Mammoth/bam/JK2782_TGGCCGATCAACGA_L008_R1_001.fastq.gz.tengrand.fq.combined.fq.mapped.bam' 
   no_read_QC = false
 }

--- a/main.nf
+++ b/main.nf
@@ -580,7 +580,7 @@ process multiqc {
     rfilename = custom_runName ? "--filename " + custom_runName.replaceAll('\\W','_').replaceAll('_+','_') + "_multiqc_report" : ''
     """
     multiqc . -s -f $rtitle $rfilename --config $multiqc_config  \\
-      -m samtools -m fastqc --verbose
+      -m samtools -m fastqc -m custom_content --verbose
     """
 }
 


### PR DESCRIPTION
Some small fixes: 

## test.config
- Removed hardcoded outdir so that the default is used.
- Removed nf-core TODO:s and input files that were commented out. 

It would be nice to add a bam file with paired-end data to the test list, I had a quick look at the nf-core test datasets, but couldn't find any at first glance. Should I write an issue about that? 

## main.nf
- Specified `custom_content` as module in MultiQC command so that software versions and workflow summary are added to the report.  